### PR TITLE
docs: set home page tab title to catchphrase

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agent Evals
+title: Evals that make agents better
 description: Industry-standard evaluation specifications for AI agents
 template: splash
 hero:


### PR DESCRIPTION
## Summary
- Changes home page `title` from "Agent Evals" to "Evals that make agents better"
- Fixes the redundant "Agent Evals | Agent Evals" browser tab — now shows "Evals that make agents better | Agent Evals"

## Risk
low — docs-only